### PR TITLE
feat: Adds http variant of mcp server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ readability/
 ai-sdk-core/
 
 docs/internal/
+docs/plans/
 .cache/
 .worktrees/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pnpm link --global
 # Sync a library's docs
 diamond sync https://mswjs.io/docs --key msw --recursive
 
-# Install as an MCP server (Claude Code, Claude Desktop, Cursor, or Gemini CLI)
+# Install as an MCP server (Claude Code, Claude Desktop, Cursor, Gemini CLI, or Codex)
 diamond install --claude-code
 
 # Start the MCP server
@@ -81,7 +81,7 @@ diamond watch
 diamond remove <id>
 
 # Automatic MCP configuration
-diamond install --claude-code --claude-desktop --cursor --gemini-cli
+diamond install --claude-code --claude-desktop --cursor --gemini-cli --codex
 ```
 
 ## MCP Tools
@@ -105,7 +105,7 @@ You can use `diamond install` to automatically configure your tools, or manually
   "mcpServers": {
     "diamond": {
       "command": "diamond",
-      "args": ["serve"]
+      "args": ["mcp"]
     }
   }
 }
@@ -117,7 +117,7 @@ You can use `diamond install` to automatically configure your tools, or manually
   "mcpServers": {
     "diamond": {
       "command": "diamond",
-      "args": ["serve"]
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -58,7 +58,7 @@ Keeps a long-running process that monitors all registered local repositories. Wh
 Automatically configure Diamond as an MCP server in your tools.
 
 ```bash
-diamond install --gemini-cli --claude-code --cursor
+diamond install --gemini-cli --claude-code --cursor --codex
 ```
 
 | Flag | Target Path |
@@ -67,6 +67,7 @@ diamond install --gemini-cli --claude-code --cursor
 | `--claude-code` | `~/.claude.json` |
 | `--claude-desktop` | `~/Library/Application Support/Claude/...` |
 | `--cursor` | `~/.cursor/mcp.json` |
+| `--codex` | `~/.codex/config.toml` |
 
 ---
 
@@ -104,7 +105,7 @@ For `docs` entries, this also deletes the versioned storage directory to reclaim
 
 ---
 
-### `diamond serve`
+### `diamond mcp`
 
 Start the Diamond MCP server over stdio. Configure this command in your AI host's settings to enable Diamond's capabilities.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -5,7 +5,7 @@ Diamond exposes its capabilities to AI assistants via the Model Context Protocol
 ## Starting the Server
 
 ```bash
-diamond serve
+diamond mcp
 ```
 
 Or configure it in your AI host's MCP settings using `diamond install`.

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -5,6 +5,7 @@
  *   - Claude Code  (~/.claude.json, user-scope mcpServers)
  *   - Claude Desktop (~/Library/Application Support/Claude/claude_desktop_config.json)
  *   - Cursor (~/.cursor/mcp.json)
+ *   - Codex (~/.codex/config.toml)
  *
  * Each target is attempted independently — a failure for one doesn't block
  * the others. The command reports success/skip/failure for each target.
@@ -115,6 +116,47 @@ function installGemini(entry: McpServerEntry): string {
   return configPath;
 }
 
+function formatTomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function formatTomlStringArray(values: string[]): string {
+  return `[${values.map((v) => formatTomlString(v)).join(', ')}]`;
+}
+
+function upsertCodexMcpServer(configText: string, name: string, entry: McpServerEntry): string {
+  const header = `[mcp_servers.${name}]`;
+  const sectionLines = [
+    header,
+    `command = ${formatTomlString(entry.command)}`,
+    `args = ${formatTomlStringArray(entry.args)}`,
+  ];
+  const section = sectionLines.join('\n');
+
+  const lines = configText.split('\n');
+  const start = lines.findIndex((line) => line.trim() === header);
+
+  if (start !== -1) {
+    let end = start + 1;
+    while (end < lines.length && !lines[end]?.trim().startsWith('[')) end += 1;
+    lines.splice(start, end - start, ...sectionLines);
+    return `${lines.join('\n').replace(/\s+$/, '')}\n`;
+  }
+
+  const trimmed = configText.replace(/\s+$/, '');
+  if (!trimmed) return `${section}\n`;
+  return `${trimmed}\n\n${section}\n`;
+}
+
+function installCodex(entry: McpServerEntry): string {
+  const configPath = path.join(os.homedir(), '.codex', 'config.toml');
+  const existing = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf8') : '';
+  const updated = upsertCodexMcpServer(existing, 'diamond', entry);
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, updated, 'utf8');
+  return configPath;
+}
+
 // ─── Target registry ─────────────────────────────────────────────────────────
 
 type Target = {
@@ -148,6 +190,12 @@ const TARGETS: Target[] = [
     install: installGemini,
     restartNote: 'New sessions will automatically include the Diamond MCP server.',
   },
+  {
+    name: 'Codex',
+    flag: 'codex',
+    install: installCodex,
+    restartNote: 'Restart Codex or open a new session to load the new MCP server.',
+  },
 ];
 
 // ─── Main export ──────────────────────────────────────────────────────────────
@@ -155,7 +203,7 @@ const TARGETS: Target[] = [
 export async function installCommand(options: { targets: string[] }) {
   const log = getLogger().child({ component: 'cli:install' });
   const diamondBin = resolveDiamondBin();
-  const entry: McpServerEntry = { command: diamondBin, args: ['serve'] };
+  const entry: McpServerEntry = { command: diamondBin, args: ['mcp'] };
 
   const activeTargets = options.targets.length > 0 ? TARGETS.filter((t) => options.targets.includes(t.flag)) : TARGETS;
 

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -1,0 +1,57 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import fs from 'fs-extra';
+import { Env } from '#src/core/env.js';
+import { McpServer } from '#src/mcp/server.js';
+
+export interface ServerState {
+  pid: number;
+  port: number;
+  startedAt: string;
+}
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function serveCommand(options: { port: number; bg: boolean }): Promise<void> {
+  const { port, bg } = options;
+
+  if (bg) {
+    if (await fs.pathExists(Env.serverStatePath)) {
+      const state: ServerState = await fs.readJson(Env.serverStatePath);
+      if (isProcessAlive(state.pid)) {
+        process.stderr.write(`Server already running (PID ${state.pid}) on port ${state.port}.\n`);
+        process.stderr.write(`Use 'diamond view server' to monitor it.\n`);
+        process.exit(0);
+      }
+    }
+
+    // Re-exec self without --bg so the child runs as a foreground server
+    const args = process.argv.slice(1).filter((a) => a !== '--bg');
+    const child = spawn(process.execPath, args, { detached: true, stdio: 'ignore' });
+    child.unref();
+
+    const pid = child.pid;
+    if (pid === undefined) {
+      process.stderr.write('Failed to start server: could not obtain child PID.\n');
+      process.exit(1);
+    }
+
+    // Write state file from parent since we know the PID immediately
+    await fs.ensureDir(path.dirname(Env.serverStatePath));
+    await fs.writeJson(Env.serverStatePath, { pid, port, startedAt: new Date().toISOString() } satisfies ServerState);
+
+    process.stdout.write(`Server started (PID ${pid}) on port ${port}\n`);
+    process.stdout.write(`Use 'diamond view server' to monitor it.\n`);
+    process.exit(0);
+  }
+
+  const server = new McpServer();
+  await server.runHttp(port);
+}

--- a/src/cli/view.ts
+++ b/src/cli/view.ts
@@ -1,0 +1,65 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import { isProcessAlive, type ServerState } from '#src/cli/serve.js';
+import { Env } from '#src/core/env.js';
+
+function formatUptime(startedAt: string): string {
+  const s = Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+export async function viewServerCommand(): Promise<void> {
+  if (!(await fs.pathExists(Env.serverStatePath))) {
+    process.stderr.write('No server is running. Start one with: diamond serve --bg\n');
+    process.exit(1);
+  }
+
+  const state: ServerState = await fs.readJson(Env.serverStatePath);
+
+  if (!isProcessAlive(state.pid)) {
+    process.stderr.write(`Server is not running (stale state, PID ${state.pid}).\n`);
+    process.stderr.write('Start one with: diamond serve --bg\n');
+    process.exit(1);
+  }
+
+  process.stdout.write('Diamond MCP Server\n');
+  process.stdout.write(`  PID:    ${state.pid}\n`);
+  process.stdout.write(`  Port:   ${state.port}\n`);
+  process.stdout.write(`  Uptime: ${formatUptime(state.startedAt)}\n`);
+  process.stdout.write(`  URL:    http://127.0.0.1:${state.port}/mcp\n`);
+  process.stdout.write('\nTailing logs (Ctrl-C to exit)...\n\n');
+
+  const logPath = path.join(Env.dataDir, 'logs', 'diamond.log');
+
+  if (!(await fs.pathExists(logPath))) {
+    process.stderr.write('Log file not found.\n');
+    process.exit(1);
+  }
+
+  let offset = (await fs.stat(logPath)).size;
+
+  async function readNewContent() {
+    const { size } = await fs.stat(logPath);
+    if (size > offset) {
+      const chunk = Buffer.alloc(size - offset);
+      const fd = await fs.open(logPath, 'r');
+      await fs.read(fd, chunk, 0, chunk.length, offset);
+      await fs.close(fd);
+      process.stdout.write(chunk);
+      offset = size;
+    }
+  }
+
+  const watcher = fs.watch(logPath, () => {
+    readNewContent().catch(() => {});
+  });
+
+  process.on('SIGINT', () => {
+    watcher.close();
+    process.exit(0);
+  });
+}

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -106,4 +106,17 @@ export const Env = {
   get registryPath() {
     return path.join(this.configDir, 'registry.json');
   },
+
+  /**
+   * The path to the running server state file.
+   *
+   * Written by `diamond serve` on startup; removed on graceful exit.
+   * Contains { pid, port, startedAt } so `diamond view server` can locate
+   * and report on the background process.
+   *
+   * Example path: `~/.local/share/diamond/server.json`
+   */
+  get serverStatePath() {
+    return path.join(this.dataDir, 'server.json');
+  },
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,9 @@ import { gcCommand } from '#src/cli/gc.js';
 import { installCommand } from '#src/cli/install.js';
 import { removeCommand } from '#src/cli/remove.js';
 import { addRepoCommand } from '#src/cli/repo.js';
+import { serveCommand } from '#src/cli/serve.js';
 import { syncCommand } from '#src/cli/sync.js';
+import { viewServerCommand } from '#src/cli/view.js';
 import { watchCommand } from '#src/cli/watch.js';
 import { getLogger, initLogger } from '#src/logger.js';
 import { McpServer } from '#src/mcp/server.js';
@@ -115,18 +117,56 @@ program
   });
 
 // -----------------------------------------------------------------------------
-// serve — launch the MCP server over stdio
+// mcp — launch the MCP server over stdio (spawned on-demand by MCP hosts)
 // -----------------------------------------------------------------------------
 program
-  .command('serve')
-  .description('Start the Diamond MCP server (connect via Claude Desktop, Cursor, etc.)')
+  .command('mcp')
+  .description('Start the Diamond MCP server over stdio (for Claude Code, Cursor, etc.)')
   .action(async () => {
-    const log = getLogger().child({ component: 'cli:serve' });
+    const log = getLogger().child({ component: 'cli:mcp' });
     try {
       const server = new McpServer();
       await server.run();
     } catch (e) {
       log.error({ err: e }, 'Fatal error in MCP server');
+      process.exit(1);
+    }
+  });
+
+// -----------------------------------------------------------------------------
+// serve — persistent HTTP/SSE MCP server (foreground or background daemon)
+// -----------------------------------------------------------------------------
+const DEFAULT_PORT = parseInt(process.env.DIAMOND_PORT ?? '65535', 10);
+
+program
+  .command('serve')
+  .description('Start the Diamond MCP server over HTTP (persistent, reconnectable)')
+  .option('--port <number>', 'Port to listen on (env: DIAMOND_PORT)', String(DEFAULT_PORT))
+  .option('--bg', 'Run as a background daemon', false)
+  .action(async (options) => {
+    const log = getLogger().child({ component: 'cli:serve' });
+    try {
+      await serveCommand({ port: parseInt(options.port, 10), bg: options.bg });
+    } catch (e) {
+      log.error({ err: e }, 'Fatal error in serve');
+      process.exit(1);
+    }
+  });
+
+// -----------------------------------------------------------------------------
+// view — inspect running Diamond services
+// -----------------------------------------------------------------------------
+const view = program.command('view').description('Inspect running Diamond services');
+
+view
+  .command('server')
+  .description('Show status and tail logs of the running background server')
+  .action(async () => {
+    const log = getLogger().child({ component: 'cli:view' });
+    try {
+      await viewServerCommand();
+    } catch (e) {
+      log.error({ err: e }, 'Fatal error in view server');
       process.exit(1);
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@
  *     • serve  — start the MCP server for AI assistant integration.
  *     • repo   — manage local git repositories in the registry.
  *
- *   As an MCP server:  `diamond serve`
- *     The serve command launches the Diamond MCP server over stdio, making
+ *   As an MCP server:  `diamond mcp`
+ *     The mcp command launches the Diamond MCP server over stdio, making
  *     all of Diamond's capabilities available to any MCP-compatible AI host
  *     (Claude Desktop, Cursor, etc.) without the user needing to run any
  *     other commands.
@@ -181,6 +181,7 @@ program
   .option('--claude-desktop', 'Install into Claude Desktop')
   .option('--cursor', 'Install into Cursor (~/.cursor/mcp.json)')
   .option('--gemini-cli', 'Install into Gemini CLI (~/.gemini/settings.json)')
+  .option('--codex', 'Install into Codex (~/.codex/config.toml)')
   .action(async (options) => {
     const log = getLogger().child({ component: 'cli:install' });
     const targets: string[] = [];
@@ -188,6 +189,7 @@ program
     if (options.claudeDesktop) targets.push('claude-desktop');
     if (options.cursor) targets.push('cursor');
     if (options.geminiCli) targets.push('gemini-cli');
+    if (options.codex) targets.push('codex');
 
     if (targets.length === 0) {
       log.warn('No install targets specified');
@@ -196,7 +198,8 @@ program
       process.stderr.write('  diamond install --claude-desktop\n');
       process.stderr.write('  diamond install --cursor\n');
       process.stderr.write('  diamond install --gemini-cli\n');
-      process.stderr.write('\nFlags can be combined: diamond install --claude-code --gemini-cli\n');
+      process.stderr.write('  diamond install --codex\n');
+      process.stderr.write('\nFlags can be combined: diamond install --claude-code --gemini-cli --codex\n');
       process.exit(0);
     }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -6,14 +6,17 @@
  * data and interact with live tools and resources.
  */
 
+import http from 'node:http';
 import path from 'node:path';
 import { ResourceTemplate, McpServer as SdkMcpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import fs from 'fs-extra';
 import * as z from 'zod';
 
 import { removeCommand } from '#src/cli/remove.js';
 import { syncCommand } from '#src/cli/sync.js';
+import { Env } from '#src/core/env.js';
 import { RegistryManager } from '#src/core/registry.js';
 import { SearchService } from '#src/core/search.js';
 import { StorageManager } from '#src/core/storage.js';
@@ -262,6 +265,43 @@ export class McpServer {
     const transport = new StdioServerTransport();
     await this.mcp.connect(transport);
     log.debug('mcp:ready');
+  }
+
+  async runHttp(port: number) {
+    const log = getLogger().child({ component: 'mcp:server' });
+
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    await this.mcp.connect(transport);
+
+    const httpServer = http.createServer((req, res) => {
+      if (req.url === '/mcp') {
+        transport.handleRequest(req, res);
+      } else {
+        res.writeHead(404);
+        res.end('Not found');
+      }
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      httpServer.on('error', reject);
+      httpServer.listen(port, '127.0.0.1', resolve);
+    });
+
+    await fs.ensureDir(path.dirname(Env.serverStatePath));
+    await fs.writeJson(Env.serverStatePath, { pid: process.pid, port, startedAt: new Date().toISOString() });
+
+    log.info({ port }, 'mcp:http_ready');
+    process.stderr.write(`Diamond MCP server running on http://127.0.0.1:${port}/mcp\n`);
+
+    const cleanup = async () => {
+      await fs.remove(Env.serverStatePath).catch(() => {});
+      await transport.close();
+      httpServer.close();
+      process.exit(0);
+    };
+
+    process.on('SIGTERM', cleanup);
+    process.on('SIGINT', cleanup);
   }
 
   private async walkRepo(dir: string, localPath: string, files: string[]) {

--- a/tests/cli/install.test.ts
+++ b/tests/cli/install.test.ts
@@ -36,7 +36,7 @@ describe('installCommand', () => {
     const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
     expect(settings.mcpServers.diamond).toEqual({
       command: '/usr/local/bin/diamond',
-      args: ['serve'],
+      args: ['mcp'],
     });
   });
 
@@ -49,8 +49,20 @@ describe('installCommand', () => {
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
     expect(config.mcpServers.diamond).toEqual({
       command: '/usr/local/bin/diamond',
-      args: ['serve'],
+      args: ['mcp'],
     });
+  });
+
+  it('should install into Codex config', async () => {
+    const configPath = path.join(tmpHome, '.codex', 'config.toml');
+
+    await installCommand({ targets: ['codex'] });
+
+    expect(fs.existsSync(configPath)).toBe(true);
+    const config = fs.readFileSync(configPath, 'utf8');
+    expect(config).toContain('[mcp_servers.diamond]');
+    expect(config).toContain('command = "/usr/local/bin/diamond"');
+    expect(config).toContain('args = ["mcp"]');
   });
 
   it('should merge with existing settings', async () => {
@@ -73,9 +85,10 @@ describe('installCommand', () => {
   });
 
   it('should install into multiple targets at once', async () => {
-    await installCommand({ targets: ['gemini-cli', 'claude-code'] });
+    await installCommand({ targets: ['gemini-cli', 'claude-code', 'codex'] });
 
     expect(fs.existsSync(path.join(tmpHome, '.gemini', 'settings.json'))).toBe(true);
     expect(fs.existsSync(path.join(tmpHome, '.claude.json'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpHome, '.codex', 'config.toml'))).toBe(true);
   });
 });


### PR DESCRIPTION
## What does this change?

This PR introduces two main updates:

  1. Splits MCP startup into diamond mcp (stdio for MCP hosts) and a new diamond serve (HTTP server, with optional --bg daemon
     mode), plus diamond view server to inspect/tail a running background server.
  2. Extends diamond install to support Codex via --codex (~/.codex/config.toml) and updates install targets to use args:
     ["mcp"] instead of ["serve"].

  It also updates docs/README to reflect the new command names and Codex support.

## Why?

serve was previously overloaded for stdio MCP host integration. This change separates concerns:

- diamond mcp is now the MCP-host-friendly stdio entrypoint.
- diamond serve is a persistent HTTP MCP endpoint better suited for reconnectable/background workflows.

Adding Codex install support removes manual configuration friction and makes onboarding consistent across supported AI tools.

## How did you test it?

- pnpm -s test tests/cli/install.test.ts
- 5/5 tests passed.
- Includes new Codex install test (.codex/config.toml creation and MCP server block content).
- Existing install tests now confirm args: ["mcp"] for generated MCP configs.

## Checklist

- [x] `pnpm lint` passes
- [x] I've described what I tested above
