### PR TITLE
docs: clarify mcp vs serve and document serve CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ diamond sync https://mswjs.io/docs --key msw --recursive
 # Install as an MCP server (Claude Code, Claude Desktop, Cursor, Gemini CLI, or Codex)
 diamond install --claude-code
 
-# Start the MCP server
-diamond serve
+# Start MCP over stdio (used by MCP hosts)
+diamond mcp
+
+# Or run a persistent local HTTP MCP endpoint
+diamond serve --port 65535 --bg
 ```
 
 That's it. Your AI assistant now has offline access to MSW's documentation.
@@ -52,7 +55,7 @@ Diamond builds two indices for every library: a fast MiniSearch keyword index an
 Content is hashed with SHA-256 and stored once, regardless of how many library versions reference it. Versioned directories are hardlinks into this store, so multiple versions cost almost nothing extra.
 
 **5. Serve over MCP.**
-`diamond serve` exposes everything to any MCP-compatible AI host via tools and resource URIs:
+`diamond mcp` (stdio) or `diamond serve` (HTTP) exposes everything to any MCP-compatible AI host via tools and resource URIs:
 
 ```
 docs://msw/latest/api/handlers     ← read a specific page
@@ -68,8 +71,17 @@ diamond sync <url> --key <name> --recursive
 # One-shot crawl to a local directory (no registry)
 diamond crawl <url> --key <name> --recursive
 
-# Start the MCP server
-diamond serve
+# Start MCP over stdio (for host-managed MCP processes)
+diamond mcp
+
+# Start persistent HTTP MCP server
+diamond serve --port 65535
+
+# Run persistent HTTP MCP server in the background
+diamond serve --bg
+
+# Inspect running background server and tail logs
+diamond view server
 
 # Register a local git repository (immediately indexed and searchable)
 diamond repo add <path> --key <name>
@@ -84,9 +96,15 @@ diamond remove <id>
 diamond install --claude-code --claude-desktop --cursor --gemini-cli --codex
 ```
 
+### Which Server Command Should I Use?
+
+- Use `diamond mcp` for Claude Code, Cursor, Codex, and other MCP hosts that spawn a stdio MCP process.
+- Use `diamond serve` when you want a persistent local HTTP endpoint (`http://127.0.0.1:<port>/mcp`), including daemon mode via `--bg`.
+- `diamond serve` defaults to port `65535`; override with `--port` or `DIAMOND_PORT`.
+
 ## MCP Tools
 
-Once `diamond serve` is running, your AI assistant has access to:
+Once your MCP host is configured with `diamond mcp` (or you run `diamond serve` for HTTP), your AI assistant has access to:
 
 | Tool | What it does |
 |---|---|
@@ -121,6 +139,13 @@ You can use `diamond install` to automatically configure your tools, or manually
     }
   }
 }
+```
+
+**Codex** (`~/.codex/config.toml`):
+```toml
+[mcp_servers.diamond]
+command = "diamond"
+args = ["mcp"]
 ```
 
 ## Storage Layout

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -109,10 +109,44 @@ For `docs` entries, this also deletes the versioned storage directory to reclaim
 
 Start the Diamond MCP server over stdio. Configure this command in your AI host's settings to enable Diamond's capabilities.
 
+---
+
+### `diamond serve`
+
+Start a persistent HTTP MCP server (foreground by default).
+
+```bash
+diamond serve
+diamond serve --port 7777
+diamond serve --bg
+```
+
+The HTTP MCP endpoint is available at `http://127.0.0.1:<port>/mcp`.
+
+| Option | Default | Description |
+|---|---|---|
+| `--port <number>` | `DIAMOND_PORT` or `65535` | Port to bind on `127.0.0.1` |
+| `--bg` | `false` | Run as a detached background daemon |
+
+---
+
+### `diamond view server`
+
+Inspect the background HTTP server and tail logs.
+
+```bash
+diamond view server
+```
+
+Displays PID, port, uptime, endpoint URL, then follows `diamond.log` until interrupted.
+
 ## Shared Behavior
 
 **Respectful Crawling.** Diamond identifies as `DiamondCrawler` and respects `robots.txt` directives (Disallow/Allow).
 
 **stdout is clean.** All progress output goes to stderr (`console.warn`). 
+
+**Environment Variables.**
+- `DIAMOND_PORT`: default port for `diamond serve` (used when `--port` is not provided).
 
 **Exit codes.** All commands exit `0` on success, `1` on any fatal error.


### PR DESCRIPTION
## What does this change?

Adds better docs:

- Explain `serve` options
- Describes when to use `serve` vs `mcp`
- Documents the default serve port